### PR TITLE
Fixes mobile navigation and also adds GitHub link to header

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -5,6 +5,7 @@
         {{ if .IsTranslated }}
             {{ range .Translations }}
                 <option value="{{ .Permalink }}" class="second_item">Switch to {{ .Lang }}</option>
+                <option disabled>──────────</option>
             {{ end }}
         {{ end }}
         {{/* We are using a hack here. Home always gets selected. This is wrong, but browser will default to apply selected only on last matched, so menu works as expected */}}
@@ -16,9 +17,9 @@
         <option value="{{ relURL "services/development-and-integrations" }}" class="second_item"  {{ if eq $slug "development-and-integrations"}}selected{{end}}>{{ i18n "development" }}</a></li>
         <option value="{{ relLangURL "/" }}#nav-events" class="second_item">{{i18n "talks"}}</option>
         <option value="{{ relLangURL "blog" }}" class="second_item"{{if eq $slug "blog"}}selected{{end}}>{{i18n "blog"}}</option>
-        <option value="{{ relURL "case-studies" }}" class="second_item"{{if eq $slug "case-studies"}}selected{{end}}>{{i18n "studies"}}</option>
+        <option value="{{ relURL "case-studies" }}" class="second_item"{{if eq $slug "case-studies"}}selected{{end}}>{{i18n "case-studies"}}</option>
         <option value="{{ relLangURL "jobs" }}" class="second_item"{{if eq $slug "jobs"}}selected{{end}}>{{i18n "jobs"}}</option>
-        <option value="{{ relLangURL "co2-formulas" }}" class="second_item"{{if eq $slug "co2-formulas"}}selected{{end}}>{{i18n "formulas"}}</option>
+        <option value="{{ relLangURL "co2-formulas" }}" class="second_item"{{if eq $slug "co2-formulas"}}selected{{end}}>{{i18n "co2-formulas"}}</option>
         <option value="{{ relLangURL "projects" }}" class="second_item">{{i18n "projects"}}</option>
         <option value="{{ relLangURL "/" }}#nav-team" class="second_item">{{i18n "team"}}</option>
         <option value="{{ relLangURL "newsroom" }}" class="second_item">{{i18n "newsroom"}}</option>
@@ -73,6 +74,15 @@
                     <div class="contentbtn">{{i18n "newsroom"}}</div>
                 </div></a>
             </li>
+            <li>
+                <a href="https://github.com/green-coding-solutions">
+                    <div class="">
+                     <div class="contentbtn"><i class="large github icon"></i></div>
+                    </div>
+                </a>
+             </li>
+
+
 
             {{ if .IsTranslated }}
                 {{ range .Translations }}


### PR DESCRIPTION
- Fixes title issue on mobile
- Adds a line after the language switcher on mobile to make it clearer and easier to find
- Adds a little GitHub icon to the menu when not on mobile. I see this all the time and quite like it as it shows we are developers. Just a suggestion though. 

<img width="1164" alt="Screenshot 2024-02-23 at 12 09 11" src="https://github.com/green-coding-solutions/website/assets/39629/512b609d-b734-481a-bfe9-40596fb646a4">
