### PR TITLE
Fixes the RSS footer links to only Newsroom

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -17,7 +17,7 @@
 
     <div class="credits" style="margin-top: 10px;">
         {{ $sections := where $.Site.Pages ".Kind" "section" }}
-        {{ range $sections }}
+        {{ range where $sections ".Page.Title" "Newsroom" }}
               {{ $site_title_rss := .Site.Title }}
               {{ $page_title_rss := .Page.Title }}
               {{ with  .OutputFormats.Get "rss" }}

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -17,11 +17,13 @@
 
     <div class="credits" style="margin-top: 10px;">
         {{ $sections := where $.Site.Pages ".Kind" "section" }}
-        {{ range where $sections ".Page.Title" "Newsroom" }}
-              {{ $site_title_rss := .Site.Title }}
-              {{ $page_title_rss := .Page.Title }}
-              {{ with  .OutputFormats.Get "rss" }}
-                  <a type="application/rss+xml" title="{{ $site_title_rss }} - {{ $page_title_rss }} Feed" href="{{.Permalink}}"><img src="/img/rss.webp" height="20"> {{ $page_title_rss }}</a>&nbsp; &nbsp;
+        {{ $feeds := dict "newsroom" "Newsroom" "blog" "Blog" "case-studies" "Case Studies" }}
+        {{ range $sections }}
+              {{ $label := index $feeds .Section }}
+              {{ if and $label .Parent.IsHome }}
+                  {{ with .OutputFormats.Get "rss" }}
+                      <a type="application/rss+xml" title="{{ $.Site.Title }} - {{ $label }} Feed" href="{{.Permalink}}"><img src="/img/rss.webp" height="20"> {{ $label }}</a>&nbsp; &nbsp;
+                  {{ end }}
               {{ end }}
         {{ end }}
     </div>


### PR DESCRIPTION
Currently the footer has a lot of empyt RSS feed items. I removed all except Newsroom as this is really the only thing

<img width="941" height="261" alt="Screenshot 2026-07-03 at 14 51 49" src="https://github.com/user-attachments/assets/a9b2122b-dfe1-44c2-8218-9ab224214ece" />


to

<img width="997" height="270" alt="Screenshot 2026-07-03 at 14 58 32" src="https://github.com/user-attachments/assets/8a875a4b-3fea-4ec2-9cce-37c8b9a9e50c" />
